### PR TITLE
Added a command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 NAME = ox-ctrl       # DFC with DFCNAND
 NAMET = ox-ctrl-test # DFC with DFCNAND + tests
 NAMEV = ox-ctrl-volt # DFC with VOLT + tests
-CORE = core.o ox-mq.o nvme.o nvme_cmd.o lightnvm.o cmd_args.o
-CORE_VOLT = core-v.o ox-mq-v.o nvme-v.o nvme_cmd-v.o lightnvm-v.o cmd_args-v.o
+CORE = core.o ox-mq.o nvme.o nvme_cmd.o lightnvm.o cmd_args.o ox_cmdline.o
+CORE_VOLT = core-v.o ox-mq-v.o nvme-v.o nvme_cmd-v.o lightnvm-v.o cmd_args-v.o ox_cmdline-v.o
 CLEAN = *.o *-v.o
 
 ### CONFIGURATION MACROS
@@ -103,13 +103,13 @@ $(TESTS_DFC_PATH)/%.o : %.c include/tests.h
 all: dfc dfc-tests dfc-volt
 
 dfc: $(CORE) $(MMGRS_DFC) $(FTLS_DFC) $(PCIE_DFC)
-	$(CC) $(CFLAGS) $(CORE) $(MMGRS_DFC) $(FTLS_DFC) $(PCIE_DFC) -o $(NAME) -lpthread
+	$(CC) $(CFLAGS) $(CORE) $(MMGRS_DFC) $(FTLS_DFC) $(PCIE_DFC) -o $(NAME) -lpthread -lreadline
 
 dfc-tests: $(CORE) $(MMGRS_DFC) $(FTLS_DFC) $(PCIE_DFC) $(TESTS_DFC)
-	$(CC) $(CFLAGS) $(CORE) $(MMGRS_DFC) $(FTLS_DFC) $(PCIE_DFC) $(TESTS_DFC) -o $(NAMET) -lpthread
+	$(CC) $(CFLAGS) $(CORE) $(MMGRS_DFC) $(FTLS_DFC) $(PCIE_DFC) $(TESTS_DFC) -o $(NAMET) -lpthread -lreadline
 
 dfc-volt: $(CORE_VOLT) $(MMGRS_VOLT) $(FTLS_DFC) $(PCIE_DFC) $(TESTS_DFC)
-	$(CC) $(CFLAGS) $(CORE_VOLT) $(MMGRS_VOLT) $(FTLS_DFC) $(PCIE_DFC) $(TESTS_DFC) -o $(NAMEV) -lpthread
+	$(CC) $(CFLAGS) $(CORE_VOLT) $(MMGRS_VOLT) $(FTLS_DFC) $(PCIE_DFC) $(TESTS_DFC) -o $(NAMEV) -lpthread -lreadline
 
 clean:
 	rm -f $(CLEAN) $(NAME) $(NAMET) $(NAMEV)

--- a/core.c
+++ b/core.c
@@ -72,6 +72,7 @@
 #include <sys/time.h>
 #include "include/uatomic.h"
 #include "include/ox-mq.h"
+#include "include/cmdline.h"
 
 LIST_HEAD(mmgr_list, nvm_mmgr) mmgr_head = LIST_HEAD_INITIALIZER(mmgr_head);
 LIST_HEAD(ftl_list, nvm_ftl) ftl_head = LIST_HEAD_INITIALIZER(ftl_head);
@@ -1046,8 +1047,7 @@ int nvm_init_ctrl (int argc, char **argv)
             break;
         case OX_RUN_MODE:
             core.run_flag ^= RUN_TESTS;
-            while(!core.nvm_nvme_ctrl->running)
-                usleep(NVM_SEC);
+            cmdline_start();
             break;
         default:
             goto CLEAN;

--- a/include/cmdline.h
+++ b/include/cmdline.h
@@ -44,6 +44,8 @@ int cmdline_set_debug (char *line, ox_cmd *cmd);
 int cmdline_show_debug (char *line, ox_cmd *cmd);
 int cmdline_exit (char *line, ox_cmd *cmd);
 
+void cmdline_start (void);
+
 char **command_completion (const char *text, int start, int end);
 char *command_generator (const char *text, int state);
 void find_command (char *line, ox_cmd **p_cmd, ox_cmd *p_cmd_list[]);

--- a/include/cmdline.h
+++ b/include/cmdline.h
@@ -1,0 +1,52 @@
+/* OX: Open-Channel NVM Express SSD Controller
+ *
+ *  - DFC NAND Media Manager
+ *
+ * Copyright (C) 2017, IT University of Copenhagen. All rights reserved.
+ * Written by Frey Alfredsson <frea@itu.dk>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+extern struct core_struct core;
+
+typedef struct ox_cmd ox_cmd;
+typedef int (*ox_cmdline_func_t)(char *line, ox_cmd *cmd);
+
+typedef struct ox_cmd {
+        char *command;
+        struct ox_cmd *next;
+        ox_cmdline_func_t func;
+        void *value;
+        char *short_help;
+        char *help;
+} ox_cmd;
+
+int cmdline_set_debug (char *line, ox_cmd *cmd);
+int cmdline_show_debug (char *line, ox_cmd *cmd);
+int cmdline_exit (char *line, ox_cmd *cmd);
+
+char **command_completion (const char *text, int start, int end);
+char *command_generator (const char *text, int state);
+void find_command (char *line, ox_cmd **p_cmd, ox_cmd *p_cmd_list[]);
+void remove_trailing_whitespace (char *line);
+int is_whitespace (const char *text);
+int is_help_cmd (char *line);

--- a/ox_cmdline.c
+++ b/ox_cmdline.c
@@ -1,0 +1,323 @@
+/* OX: Open-Channel NVM Express SSD Controller
+ *
+ *  - DFC NAND Media Manager
+ *
+ * Copyright (C) 2017, IT University of Copenhagen. All rights reserved.
+ * Written by Frey Alfredsson <frea@itu.dk>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <readline/readline.h>
+#include <readline/history.h>
+#include "include/ssd.h"
+#include "include/cmdline.h"
+
+static char *seperator = " \t";
+
+static int debug_on = 1;
+static int debug_off = 0;
+ox_cmd debug_cmd[] = {
+        { "on",
+          NULL,
+          cmdline_set_debug,
+          &debug_on,
+          "Enables debugging",
+          "Enables debugging\n"
+          "\n"
+          "    Will enable the display of live debugging information of NVMe commands"
+        },
+        { "off",
+          NULL,
+          cmdline_set_debug,
+          &debug_off,
+          "Disables debugging",
+          "Disables debugging\n"
+          "\n"
+          "    Will disable the display of live debugging information of NVMe commands"
+        },
+        { NULL, NULL, NULL, NULL, NULL, NULL }
+};
+
+ox_cmd show_cmd[] = {
+        { "debug",
+          NULL,
+          cmdline_show_debug,
+          NULL,
+          "Disables debugging",
+          "Shows if debugging mode is enabled\n"
+          "\n"
+          "    Displays if reporting of live debugging information of NVMe commands"
+          "    is enabled"
+        },
+        { NULL, NULL, NULL, NULL, NULL, NULL }
+};
+
+ox_cmd main_cmd[] = {
+        { "help",
+          &main_cmd[1],
+          NULL,
+          NULL,
+          "Display information about builtin commands.",
+          "Usage: help [command]\n"
+          "    Display information about builtin commands.\n"
+          "\n"
+          "    Displays brief summaries of builtin commands. If a command is\n"
+          "    specified, it will give a listing of all its sub-commands."
+        },
+        { "debug",
+          debug_cmd,
+          NULL,
+          NULL,
+          "Enables or disables debugging output",
+          "Usage: debug [sub-command]\n"
+          "    Enables or disables debugging output."
+        },
+        { "show",
+          show_cmd,
+          NULL,
+          NULL,
+          "Displays run-time information",
+          "Usage: show [sub-command]\n"
+          "    Displays run-time information and status information."
+        },
+        { "exit",
+          NULL,
+          cmdline_exit,
+          NULL,
+          "Exit the OX application",
+          "Usage: exit\n"
+          "    Exit the OX application\n"
+          "\n"
+          "    Exits the OX application and gracefully turns off all controller\n"
+          "    functionality."
+
+
+        },
+        { NULL, NULL, NULL, NULL, NULL, NULL }
+};
+
+void cmdline_longhelp (ox_cmd *cmd)
+{
+        ox_cmd *cmd_list = NULL;
+        ox_cmd *subcmd;
+        int cmd_index = 0;
+
+        printf("%s: %s\n", cmd->command, cmd->help);
+        if (!cmd->next)
+                return;
+        cmd_list = cmd->next;
+        printf("\n");
+        printf("    List of sub-commands:\n");
+        while ((subcmd = &cmd_list[cmd_index++])->command) {
+                printf("        %s:\t%s\n", subcmd->command, subcmd->short_help);
+        }
+}
+
+int cmdline_set_debug (char *line, ox_cmd *cmd)
+{
+        core.debug = *((int *)(cmd->value));
+
+        printf("OX: debugging %s\n", core.debug ? "enabled" : "disabled");
+        return 0;
+}
+
+int cmdline_show_debug (char *line, ox_cmd *cmd)
+{
+        printf("OX: debugging is %s\n", core.debug ? "on" : "off");
+        return 0;
+}
+
+int cmdline_exit (char *line, ox_cmd *cmd)
+{
+        core.nvm_nvme_ctrl->running = 1;
+}
+
+void cmdline_runcommand (char *line, ox_cmd *cmd)
+{
+        if (cmd->func) {
+                cmd->func(line, cmd);
+        }
+        else {
+                printf("%s: Incomplete command, missing sub-command\n",
+                       cmd->command);
+                printf("    %s\n", cmd->short_help ? cmd->short_help : "N/A");
+        }
+}
+
+int is_help_cmd (char *line)
+{
+        char *token_line = strdup(line);
+        char *tok_state;
+        char *word = strtok_r(token_line, seperator, &tok_state);
+        if (word && !strcmp("help", word)) {
+                return 1;
+        }
+        return 0;
+}
+
+void remove_trailing_whitespace (char *line)
+{
+        char *end = line + strlen(line) - 1;
+        while (end > line && isspace((unsigned char) *end))
+                end--;
+        *(end + 1) = 0; // New end of string
+}
+
+void cmdline_start (void)
+{
+        rl_attempted_completion_function = command_completion;
+
+        while (!core.nvm_nvme_ctrl->running) {
+                char *buffer = readline("ox> ");
+                if (!buffer || is_whitespace(buffer)) {
+                        continue;
+                }
+                remove_trailing_whitespace(buffer);
+                ox_cmd *cmd;
+                ox_cmd *cmd_list;
+                find_command(buffer, &cmd, &cmd_list);
+                if (cmd == NULL) {
+                        printf("%s: command not found.\n", buffer);
+                }
+                else if (is_help_cmd(buffer)) {
+                        if (cmd->help) {
+                                cmdline_longhelp(cmd);
+                        }
+                        else {
+                                printf("%s: Missing help string\n", cmd->command);
+                        }
+                }
+                else {
+                        cmdline_runcommand(buffer, cmd);
+                }
+                add_history(buffer);
+                free(buffer);
+        }
+}
+
+int is_full_match (const char *word, ox_cmd *cmd)
+{
+        int len = strlen(cmd->command);
+        return !strncmp(word, cmd->command, len);
+}
+
+void find_command (char *line, ox_cmd **p_cmd, ox_cmd *p_cmd_list[])
+{
+        ox_cmd *cmd_list = main_cmd;
+        ox_cmd *comp_cmd = NULL;
+        ox_cmd *cmd = NULL;
+
+        char *token_line = strdup(line);
+        char *tok_state;
+        char *word = strtok_r(token_line, seperator, &tok_state);
+        while (word != NULL) {
+                int cmd_index = 0;
+                int len = strlen(word);
+
+                int found = 0;
+                int full_match = 0;
+                if (!cmd_list) {
+                        break;
+                }
+                while (!found && (comp_cmd = &cmd_list[cmd_index++])) {
+                        if (comp_cmd->command == NULL) {
+                                cmd_list = NULL;
+                                break;
+                        }
+                        if (strncmp(comp_cmd->command, word, len) == 0) {
+                                full_match = is_full_match(word, comp_cmd);
+                                if (full_match) {
+                                        cmd = comp_cmd;
+                                }
+                                found = 1;
+                                break;
+                        }
+                }
+                if (full_match) {
+                        if (full_match && comp_cmd->next) {
+                                cmd_list = comp_cmd->next;
+                        }
+                        else {
+                                cmd_list = NULL;
+                        }
+                }
+                word = strtok_r(NULL, seperator, &tok_state);
+                if (word) {
+                        cmd = NULL;
+                }
+        }
+        free(token_line);
+        *p_cmd = cmd;
+        *p_cmd_list = cmd_list;
+}
+
+char **command_completion (const char *text, int start, int end)
+{
+        rl_attempted_completion_over = 1;
+        return rl_completion_matches(text, command_generator);
+}
+
+int is_whitespace (const char *text)
+{
+        const char *ch = text;
+        while (*ch) {
+                if (!isspace(*ch)) {
+                        return 0;
+                }
+                ch++;
+        }
+        return 1;
+}
+
+char *command_generator (const char *text, int state)
+{
+        static int cmd_index;
+        static int len;
+        static ox_cmd *cmd_list;
+        static ox_cmd *cmd;
+        char *cmd_name;
+        const char *comp_cmd = !is_whitespace(text) ? text : "";
+        if (!state) {
+                cmd_index = 0;
+                len = strlen(text);
+                find_command(rl_line_buffer, &cmd, &cmd_list);
+        }
+
+        if (cmd && is_full_match(text, cmd)) {
+                char *command = strdup(cmd->command);
+                cmd = NULL;
+                cmd_list = NULL;
+                return command;
+        }
+        if (!cmd_list) {
+                return NULL;
+        }
+        while ((cmd_name = cmd_list[cmd_index++].command)) {
+                if (strncmp(cmd_name, comp_cmd, len) == 0) {
+                        return strdup(cmd_name);
+                }
+        }
+        return NULL;
+}

--- a/ox_cmdline.c
+++ b/ox_cmdline.c
@@ -1,6 +1,6 @@
 /* OX: Open-Channel NVM Express SSD Controller
  *
- *  - DFC NAND Media Manager
+ *  - OX Command line
  *
  * Copyright (C) 2017, IT University of Copenhagen. All rights reserved.
  * Written by Frey Alfredsson <frea@itu.dk>
@@ -66,7 +66,7 @@ ox_cmd show_cmd[] = {
           NULL,
           cmdline_show_debug,
           NULL,
-          "Disables debugging",
+          "Shows if debugging mode is enabled",
           "Shows if debugging mode is enabled\n"
           "\n"
           "    Displays if reporting of live debugging information of NVMe commands"

--- a/ox_cmdline.c
+++ b/ox_cmdline.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <signal.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "include/ssd.h"
@@ -185,8 +186,25 @@ void remove_trailing_whitespace (char *line)
         *(end + 1) = 0; // New end of string
 }
 
+static void sigint_handler (int handle)
+{
+        // Ignore for now, cancel running commands in the future
+}
+
 void cmdline_start (void)
 {
+        struct sigaction new_sa;
+        struct sigaction old_sa;
+        sigfillset(&new_sa.sa_mask);
+        new_sa.sa_handler = SIG_IGN;
+        new_sa.sa_flags = 0;
+
+        if (sigaction(SIGINT, &new_sa, &old_sa) == 0
+            && old_sa.sa_handler != SIG_IGN) {
+                new_sa.sa_handler = sigint_handler;
+                sigaction(SIGINT, &new_sa, 0);
+        }
+
         rl_attempted_completion_function = command_completion;
 
         while (!core.nvm_nvme_ctrl->running) {


### PR DESCRIPTION
Hi.
In this pull request I've added a command line to ox. It has autocomplete and a help system, but only contains a way to enable and disable debugging at the moment.

    ox> 
    debug  exit   help   show   
    ox> help
    help: Usage: help [command]
        Display information about builtin commands.

        Displays brief summaries of builtin commands. If a command is
        specified, it will give a listing of all its sub-commands.

    List of sub-commands:
        debug:  Enables or disables debugging output
        show:   Displays run-time information
        exit:   Exit the OX application
    ox> show debug  
    OX: debugging is on
    ox> debug off
    OX: debugging disabled
    ox> show debug                                                                    
    OX: debugging is off
    ox> 