### PR TITLE
Added the command line command  "show mq status"

### DIFF
--- a/include/cmdline.h
+++ b/include/cmdline.h
@@ -42,6 +42,7 @@ typedef struct ox_cmd {
 
 int cmdline_set_debug (char *line, ox_cmd *cmd);
 int cmdline_show_debug (char *line, ox_cmd *cmd);
+int cmdline_show_mq_status (char *line, ox_cmd *cmd);
 int cmdline_exit (char *line, ox_cmd *cmd);
 
 void cmdline_start (void);

--- a/ox_cmdline.c
+++ b/ox_cmdline.c
@@ -47,7 +47,7 @@ ox_cmd debug_cmd[] = {
           "Enables debugging",
           "Enables debugging\n"
           "\n"
-          "    Will enable the display of live debugging information of NVMe commands"
+          "    Will enable the display of live debugging information of NVMe commands."
         },
         { "off",
           NULL,
@@ -56,7 +56,28 @@ ox_cmd debug_cmd[] = {
           "Disables debugging",
           "Disables debugging\n"
           "\n"
-          "    Will disable the display of live debugging information of NVMe commands"
+          "    Will disable the display of live debugging information of NVMe commands."
+        },
+        { NULL, NULL, NULL, NULL, NULL, NULL }
+};
+
+ox_cmd mq_cmd[] = {
+        { "status",
+          NULL,
+          cmdline_show_mq_status,
+          NULL,
+          "Shows the status of all the internal mq queues",
+          "Shows the status of all the internal mq queues\n"
+          "\n"
+          "    Displays run-time status of the internal queue groups of mq. This includes\n"
+          "    their name and status of each queue.\n"
+          "      Key  Description\n"
+          "      Q:   Queue number\n"
+          "      SF:  Submission Free queue  -  Available for new submission entries\n"
+          "      SU:  Submission Used queue  -  Ready to be processed\n"
+          "      SW:  Submission Wait queue  -  In process\n"
+          "      CF:  Completion Free queue  -  Available for new completion entries\n"
+          "      CU:  Completion Used queue  -  Processed, but waiting for completion\n"
         },
         { NULL, NULL, NULL, NULL, NULL, NULL }
 };
@@ -70,14 +91,22 @@ ox_cmd show_cmd[] = {
           "Shows if debugging mode is enabled\n"
           "\n"
           "    Displays if reporting of live debugging information of NVMe commands"
-          "    is enabled"
+          "    is enabled."
+        },
+        { "mq",
+          mq_cmd,
+          NULL,
+          NULL,
+          "Displays run-time information for multi-queue",
+          "Usage: show mq [sub-command]\n"
+          "    Displays run-time information and status information for multi-queue."
         },
         { NULL, NULL, NULL, NULL, NULL, NULL }
 };
 
 ox_cmd main_cmd[] = {
         { "help",
-          &main_cmd[1],
+          &main_cmd[1],  // Skip help in auto-complete
           NULL,
           NULL,
           "Display information about builtin commands.",
@@ -147,6 +176,12 @@ int cmdline_set_debug (char *line, ox_cmd *cmd)
 int cmdline_show_debug (char *line, ox_cmd *cmd)
 {
         printf("OX: debugging is %s\n", core.debug ? "on" : "off");
+        return 0;
+}
+
+int cmdline_show_mq_status (char *line, ox_cmd *cmd)
+{
+        ox_mq_show_all();
         return 0;
 }
 


### PR DESCRIPTION
I've added a new command to the command line that prints out the status of the mq queues as follows:

> ox> help show mq status
> status: Shows the status of all the internal mq queues
> 
>     Displays run-time status of the internal queue groups of mq. This includes
>     their name and status of each queue.
>       Key  Description
>       Q:   Queue number
>       SF:  Submission Free queue  -  Available for new submission entries
>       SU:  Submission Used queue  -  Ready to be processed
>       SW:  Submission Wait queue  -  In process
>       CF:  Completion Free queue  -  Available for new completion entries
>       CU:  Completion Used queue  -  Processed, but waiting for completion
> 
> ox> show mq status
> ox-mq: FTL_LNVM
>     Q00: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q01: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q02: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q03: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q04: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q05: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q06: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q07: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     EXT00: TO: 0, TO_BACK: 0
> ox-mq: DFCNAND_MMGR
>     Q00: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q01: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q02: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q03: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q04: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q05: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q06: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     Q07: SF: 64, SU: 0, SW: 0, CF: 64, CU: 0
>     EXT00: TO: 0, TO_BACK: 0
> ox> 
> 