### PR TITLE
Added the admin commands create-bbt and erase-blk to the command line

### DIFF
--- a/core.c
+++ b/core.c
@@ -1088,7 +1088,7 @@ int nvm_init_ctrl (int argc, char **argv)
     }
 
     if (core.tests_init->init) {
-        pthread_create(&mode_t, NULL, modet_fn, NULL);
+        pthread_create(&mode_t, NULL, modet_fn, core.args_global);
         pthread_join(mode_t, NULL);
     }
 

--- a/include/cmdline.h
+++ b/include/cmdline.h
@@ -43,6 +43,7 @@ typedef struct ox_cmd {
 int cmdline_set_debug (char *line, ox_cmd *cmd);
 int cmdline_show_debug (char *line, ox_cmd *cmd);
 int cmdline_show_mq_status (char *line, ox_cmd *cmd);
+int cmdline_admin (char *line, ox_cmd *cmd);
 int cmdline_exit (char *line, ox_cmd *cmd);
 
 void cmdline_start (void);

--- a/ox_cmdline.c
+++ b/ox_cmdline.c
@@ -77,7 +77,7 @@ ox_cmd mq_cmd[] = {
           "      SU:  Submission Used queue  -  Ready to be processed\n"
           "      SW:  Submission Wait queue  -  In process\n"
           "      CF:  Completion Free queue  -  Available for new completion entries\n"
-          "      CU:  Completion Used queue  -  Processed, but waiting for completion\n"
+          "      CU:  Completion Used queue  -  Processed, but waiting for completion"
         },
         { NULL, NULL, NULL, NULL, NULL, NULL }
 };
@@ -90,7 +90,7 @@ ox_cmd show_cmd[] = {
           "Shows if debugging mode is enabled",
           "Shows if debugging mode is enabled\n"
           "\n"
-          "    Displays if reporting of live debugging information of NVMe commands"
+          "    Displays if reporting of live debugging information of NVMe commands\n"
           "    is enabled."
         },
         { "mq",

--- a/ox_cmdline.c
+++ b/ox_cmdline.c
@@ -33,6 +33,7 @@
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "include/ssd.h"
+#include "include/tests.h"
 #include "include/cmdline.h"
 
 static char *seperator = " \t";
@@ -57,6 +58,32 @@ ox_cmd debug_cmd[] = {
           "Disables debugging\n"
           "\n"
           "    Will disable the display of live debugging information of NVMe commands."
+        },
+        { NULL, NULL, NULL, NULL, NULL, NULL }
+};
+
+ox_cmd admin_cmd[] = {
+        { "create-bbt",
+          NULL,
+          cmdline_admin,
+          "create-bbt",
+          "Create or update the bad block table",
+          "Create or update the bad block table\n"
+          "\n"
+          "    An interactive command that creates or updates the bad block table,\n"
+          "    which offers two modes:\n"
+          "        1 - Full scan (Check all blocks by erasing, writing and reading)\n"
+          "        2 - Emergency table (Creates an empty bad block table without\n"
+          "            erasing blocks)"
+        },
+        { "erase_blk",
+          NULL,
+          cmdline_admin,
+          "erase-blk",
+          "Erase specific block",
+          "Erase specific block\n"
+          "\n"
+          "    An interactive command that allows you to erase any specified block."
         },
         { NULL, NULL, NULL, NULL, NULL, NULL }
 };
@@ -132,6 +159,14 @@ ox_cmd main_cmd[] = {
           "Usage: show [sub-command]\n"
           "    Displays run-time information and status information."
         },
+        { "admin",
+          admin_cmd,
+          NULL,
+          NULL,
+          "Used for testing",
+          "Usage: show [sub-command]\n"
+          "    "
+        },
         { "exit",
           NULL,
           cmdline_exit,
@@ -182,6 +217,25 @@ int cmdline_show_debug (char *line, ox_cmd *cmd)
 int cmdline_show_mq_status (char *line, ox_cmd *cmd)
 {
         ox_mq_show_all();
+        return 0;
+}
+
+int cmdline_admin (char *line, ox_cmd *cmd)
+{
+        struct nvm_init_arg args = {
+                4,
+                1,
+                CMDARG_FLAG_T,
+                { '\0' },
+                { '\0' },
+                { '\0' },
+        };
+        strcpy(args.admin_task, (char*) cmd->value);
+        if (core.tests_init->admin) {
+                core.tests_init->admin(&args);
+        } else {
+                printf("ox: Functionality not included in this binary\n");
+        }
         return 0;
 }
 

--- a/test/test_core.c
+++ b/test/test_core.c
@@ -272,7 +272,7 @@ void *tests_start (void *arg)
 
 void *tests_admin (void *arg)
 {
-    ox_admin_init (core.args_global);
+    ox_admin_init (arg);
 }
 
 void tests_complete_io  (NvmeRequest *req)


### PR DESCRIPTION
This patch adds the two command line admin commands create-bbt and erase-blk. These allow you to run the already implemented commands at run-time, in contrast to at startup time.